### PR TITLE
feature: Add feedback button to documentation The documentation's

### DIFF
--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -181,6 +181,23 @@
 
             #navWrap {
                 padding: 1em;
+                display: flex;
+                gap: 8px;
+                align-items: center;
+            }
+
+            #navWrap > a {
+                background-color: #8b5cf6;
+                color: #fff;
+                padding: 1em 1em;
+                border-radius: 8px;
+                text-decoration: none;
+                transition: all 0.3s ease;
+            }
+
+            #navWrap > a:hover {
+                background-color: #e5e7eb;
+                color: #374151;
             }
 
             #sectNav {
@@ -746,6 +763,12 @@
                 </div>
             </div>
             <div id="navWrap">
+                <a
+                    class="button"
+                    href="https://github.com/krishnadubagunta/plumcache/issues/new"
+                >
+                    Feedback
+                </a>
                 <input
                     type="search"
                     id="search"

--- a/zig-out/docs/index.html
+++ b/zig-out/docs/index.html
@@ -181,6 +181,23 @@
 
             #navWrap {
                 padding: 1em;
+                display: flex;
+                gap: 8px;
+                align-items: center;
+            }
+
+            #navWrap > a {
+                background-color: #8b5cf6;
+                color: #fff;
+                padding: 1em 1em;
+                border-radius: 8px;
+                text-decoration: none;
+                transition: all 0.3s ease;
+            }
+
+            #navWrap > a:hover {
+                background-color: #e5e7eb;
+                color: #374151;
             }
 
             #sectNav {
@@ -746,6 +763,12 @@
                 </div>
             </div>
             <div id="navWrap">
+                <a
+                    class="button"
+                    href="https://github.com/krishnadubagunta/plumcache/issues/new"
+                >
+                    Feedback
+                </a>
                 <input
                     type="search"
                     id="search"


### PR DESCRIPTION
navigation bar has been updated to include a new "Feedback" button. This button provides a direct link to create a new issue on the GitHub repository, allowing users to easily provide feedback or report issues.

Styling has been added to `#navWrap` to arrange elements using flexbox and define a gap between them. The new "Feedback" button (`#navWrap > a`) has been styled with a background color, text color, padding, border-radius, and a hover effect for better user experience.

The `docs/templates/index.html` file, which is the template for the documentation, and the generated `zig-out/docs/index.html` have both been updated to reflect these changes.

The `zig-out/docs/sources.tar` file has also been updated, which is expected as it contains the source files for the documentation.